### PR TITLE
CGPTFactory Refactor

### DIFF
--- a/quantum/__init__.py
+++ b/quantum/__init__.py
@@ -1,0 +1,57 @@
+"""
+Quantum computing package for advanced quantum simulations and experiments.
+This package provides tools for quantum circuit manipulation, black hole simulations,
+quantum communication, and error correction.
+"""
+
+from .circuits.basic_circuits import (
+    create_base_circuit,
+    create_entangled_system,
+    create_teleportation_circuit,
+    create_holographic_circuit,
+    create_entanglement_wedge_circuit
+)
+
+from .analysis.entropy import (
+    qiskit_entropy,
+    shannon_entropy,
+    measure_subsystem_entropies,
+    calculate_von_neumann_entropy,
+    analyze_subsystem_qiskit_entropy,
+    compute_mutual_information
+)
+
+from .gravity.black_hole import (
+    black_hole_simulation,
+    information_paradox_test,
+    hawking_radiation_recovery,
+    create_black_hole_curvature
+)
+
+from .communication.quantum_telephone import (
+    multiversal_telephone,
+    send_quantum_message_real,
+    dual_channel_communication,
+    amplify_target_state
+)
+
+from .error_correction.qec import (
+    charge_preserving_qec,
+    shor_qec_noisy,
+    apply_charge_preserving_qec,
+    detect_and_correct_errors
+)
+
+from .utils.quantum_utils import (
+    get_best_backend,
+    is_simulator,
+    select_backend,
+    initialize_qubits,
+    apply_entanglement,
+    measure_and_reset,
+    run_circuit_statevector,
+    process_sampler_result
+)
+
+__version__ = '0.1.0'
+__author__ = 'Quantum Research Team' 

--- a/quantum/analysis/entropy.py
+++ b/quantum/analysis/entropy.py
@@ -1,0 +1,99 @@
+"""
+Quantum entropy analysis functions.
+This module provides tools for calculating and analyzing various types of quantum entropy.
+"""
+
+from qiskit.quantum_info import Statevector, entropy
+import numpy as np
+from typing import Dict, List, Tuple
+
+def qiskit_entropy(rho):
+    """
+    Calculate von Neumann entropy using Qiskit's built-in function.
+    
+    Args:
+        rho: Density matrix or statevector
+        
+    Returns:
+        float: von Neumann entropy
+    """
+    return entropy(rho)
+
+def shannon_entropy(probs):
+    """
+    Calculate Shannon entropy for a probability distribution.
+    
+    Args:
+        probs: Probability distribution
+        
+    Returns:
+        float: Shannon entropy
+    """
+    probs = np.array(probs)
+    probs = probs[probs > 0]
+    return -np.sum(probs * np.log2(probs))
+
+def measure_subsystem_entropies(state: Statevector, num_qubits: int) -> Dict[int, float]:
+    """
+    Measure entropies of all possible subsystems.
+    
+    Args:
+        state: Quantum state
+        num_qubits: Total number of qubits
+        
+    Returns:
+        Dict[int, float]: Dictionary mapping subsystem size to entropy
+    """
+    entropies = {}
+    for i in range(1, num_qubits):
+        subsystem = list(range(i))
+        entropies[i] = entropy(state, subsystem)
+    return entropies
+
+def calculate_von_neumann_entropy(qc, num_radiation_qubits):
+    """
+    Calculate von Neumann entropy for a quantum circuit with radiation qubits.
+    
+    Args:
+        qc: Quantum circuit
+        num_radiation_qubits: Number of radiation qubits
+        
+    Returns:
+        float: von Neumann entropy
+    """
+    state = Statevector.from_instruction(qc)
+    return entropy(state, list(range(num_radiation_qubits)))
+
+def analyze_subsystem_qiskit_entropy(statevector):
+    """
+    Analyze subsystem entropies using Qiskit's entropy function.
+    
+    Args:
+        statevector: Quantum state vector
+        
+    Returns:
+        Dict[int, float]: Dictionary of subsystem entropies
+    """
+    n_qubits = int(np.log2(len(statevector)))
+    entropies = {}
+    for i in range(1, n_qubits):
+        subsystem = list(range(i))
+        entropies[i] = entropy(statevector, subsystem)
+    return entropies
+
+def compute_mutual_information(statevector, subsystem_a, subsystem_b):
+    """
+    Compute mutual information between two subsystems.
+    
+    Args:
+        statevector: Quantum state vector
+        subsystem_a: First subsystem indices
+        subsystem_b: Second subsystem indices
+        
+    Returns:
+        float: Mutual information
+    """
+    S_a = entropy(statevector, subsystem_a)
+    S_b = entropy(statevector, subsystem_b)
+    S_ab = entropy(statevector, subsystem_a + subsystem_b)
+    return S_a + S_b - S_ab 

--- a/quantum/circuits/basic_circuits.py
+++ b/quantum/circuits/basic_circuits.py
@@ -1,0 +1,84 @@
+"""
+Basic quantum circuit creation and manipulation functions.
+This module provides fundamental quantum circuit operations and basic circuit creation utilities.
+"""
+
+from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+from qiskit.quantum_info import Statevector
+import numpy as np
+
+def create_base_circuit(clbits=2):
+    """
+    Create a basic quantum circuit with specified number of classical bits.
+    
+    Args:
+        clbits (int): Number of classical bits in the circuit
+        
+    Returns:
+        QuantumCircuit: A basic quantum circuit
+    """
+    qr = QuantumRegister(2)
+    cr = ClassicalRegister(clbits)
+    qc = QuantumCircuit(qr, cr)
+    return qc
+
+def create_entangled_system(n_qubits=3):
+    """
+    Create a circuit with an entangled system of n qubits.
+    
+    Args:
+        n_qubits (int): Number of qubits to entangle
+        
+    Returns:
+        QuantumCircuit: Circuit with entangled qubits
+    """
+    qc = QuantumCircuit(n_qubits)
+    qc.h(0)
+    for i in range(1, n_qubits):
+        qc.cx(0, i)
+    return qc
+
+def create_teleportation_circuit():
+    """
+    Create a quantum teleportation circuit.
+    
+    Returns:
+        QuantumCircuit: Circuit implementing quantum teleportation
+    """
+    qc = QuantumCircuit(3, 2)
+    # Create Bell state
+    qc.h(1)
+    qc.cx(1, 2)
+    # Teleportation protocol
+    qc.cx(0, 1)
+    qc.h(0)
+    return qc
+
+def create_holographic_circuit():
+    """
+    Create a circuit implementing holographic encoding.
+    
+    Returns:
+        QuantumCircuit: Circuit with holographic encoding
+    """
+    qc = QuantumCircuit(3)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+    return qc
+
+def create_entanglement_wedge_circuit():
+    """
+    Create a circuit implementing an entanglement wedge.
+    
+    Returns:
+        QuantumCircuit: Circuit with entanglement wedge structure
+    """
+    qc = QuantumCircuit(5)
+    # Create boundary-bulk entanglement
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(1, 2)
+    qc.cx(2, 3)
+    qc.cx(3, 4)
+    return qc 

--- a/quantum/communication/quantum_telephone.py
+++ b/quantum/communication/quantum_telephone.py
@@ -1,0 +1,148 @@
+"""
+Quantum communication and teleportation functions.
+This module provides tools for quantum communication protocols and message encoding.
+"""
+
+from qiskit import QuantumCircuit, Aer
+from qiskit.quantum_info import Statevector
+import numpy as np
+from typing import Dict, List, Tuple
+
+def multiversal_telephone(message, shots=2048):
+    """
+    Implement a multiversal quantum telephone protocol.
+    
+    Args:
+        message (str): Message to be transmitted
+        shots (int): Number of measurement shots
+        
+    Returns:
+        Dict: Results of the quantum communication
+    """
+    # Convert message to binary
+    binary_message = ''.join(format(ord(c), '08b') for c in message)
+    n_qubits = len(binary_message)
+    
+    qc = QuantumCircuit(n_qubits, n_qubits)
+    
+    # Encode message
+    for i, bit in enumerate(binary_message):
+        if bit == '1':
+            qc.x(i)
+            
+    # Create entanglement
+    for i in range(0, n_qubits-1, 2):
+        qc.h(i)
+        qc.cx(i, i+1)
+        
+    # Measure
+    qc.measure_all()
+    
+    return qc
+
+def send_quantum_message_real(message: str, entropy_per_char: float = 0.75, shots: int = 8192):
+    """
+    Send a quantum message with specified entropy per character.
+    
+    Args:
+        message (str): Message to be sent
+        entropy_per_char (float): Target entropy per character
+        shots (int): Number of measurement shots
+        
+    Returns:
+        Dict: Results of the quantum communication
+    """
+    n_qubits = len(message) * 8  # 8 bits per character
+    qc = QuantumCircuit(n_qubits, n_qubits)
+    
+    # Encode message with entropy control
+    for i, char in enumerate(message):
+        char_bits = format(ord(char), '08b')
+        for j, bit in enumerate(char_bits):
+            qubit_idx = i * 8 + j
+            if bit == '1':
+                qc.x(qubit_idx)
+            # Add entropy
+            qc.rz(entropy_per_char, qubit_idx)
+            
+    # Create entanglement structure
+    for i in range(0, n_qubits-1, 2):
+        qc.h(i)
+        qc.cx(i, i+1)
+        
+    qc.measure_all()
+    return qc
+
+def dual_channel_communication(message_rad1, message_rad2, shots=2048, scaling_factor=0.6):
+    """
+    Implement dual-channel quantum communication.
+    
+    Args:
+        message_rad1 (str): First message
+        message_rad2 (str): Second message
+        shots (int): Number of measurement shots
+        scaling_factor (float): Scaling factor for entanglement
+        
+    Returns:
+        Dict: Results of the dual-channel communication
+    """
+    n_qubits = max(len(message_rad1), len(message_rad2)) * 8
+    qc = QuantumCircuit(n_qubits, n_qubits)
+    
+    # Encode first message
+    for i, char in enumerate(message_rad1):
+        char_bits = format(ord(char), '08b')
+        for j, bit in enumerate(char_bits):
+            qubit_idx = i * 8 + j
+            if bit == '1':
+                qc.x(qubit_idx)
+                
+    # Encode second message with phase
+    for i, char in enumerate(message_rad2):
+        char_bits = format(ord(char), '08b')
+        for j, bit in enumerate(char_bits):
+            qubit_idx = i * 8 + j
+            if bit == '1':
+                qc.rz(np.pi * scaling_factor, qubit_idx)
+                
+    # Create entanglement structure
+    for i in range(0, n_qubits-1, 2):
+        qc.h(i)
+        qc.cx(i, i+1)
+        
+    qc.measure_all()
+    return qc
+
+def amplify_target_state(target_bits, charge_history, shots=2048, scaling_factor=0.25):
+    """
+    Amplify a target quantum state using charge history.
+    
+    Args:
+        target_bits (str): Target state in binary
+        charge_history (List[float]): History of charge injections
+        shots (int): Number of measurement shots
+        scaling_factor (float): Scaling factor for amplification
+        
+    Returns:
+        QuantumCircuit: Circuit implementing state amplification
+    """
+    n_qubits = len(target_bits)
+    qc = QuantumCircuit(n_qubits, n_qubits)
+    
+    # Initial state preparation
+    for i, bit in enumerate(target_bits):
+        if bit == '1':
+            qc.x(i)
+            
+    # Apply charge history
+    for charge in charge_history:
+        for i in range(n_qubits):
+            qc.rz(charge * scaling_factor, i)
+            
+    # Create entanglement
+    for i in range(0, n_qubits-1, 2):
+        qc.h(i)
+        qc.cx(i, i+1)
+        
+    qc.measure_all()
+    return qc 

--- a/quantum/error_correction/qec.py
+++ b/quantum/error_correction/qec.py
@@ -1,0 +1,134 @@
+"""
+Quantum error correction functions.
+This module provides tools for implementing various quantum error correction protocols.
+"""
+
+from qiskit import QuantumCircuit, Aer
+from qiskit.quantum_info import Statevector
+import numpy as np
+from typing import Dict, List, Tuple
+
+def charge_preserving_qec(num_logical_qubits=2):
+    """
+    Implement charge-preserving quantum error correction.
+    
+    Args:
+        num_logical_qubits (int): Number of logical qubits to protect
+        
+    Returns:
+        QuantumCircuit: Circuit implementing charge-preserving QEC
+    """
+    n_qubits = 3 * num_logical_qubits  # 3 physical qubits per logical qubit
+    qc = QuantumCircuit(n_qubits, n_qubits)
+    
+    # Encode logical qubits
+    for i in range(0, n_qubits, 3):
+        qc.cx(i, i+1)
+        qc.cx(i, i+2)
+        
+    # Add stabilizer measurements
+    for i in range(0, n_qubits, 3):
+        qc.h(i)
+        qc.cx(i, i+1)
+        qc.cx(i, i+2)
+        qc.h(i)
+        
+    return qc
+
+def shor_qec_noisy(num_logical_qubits=1):
+    """
+    Implement Shor's error correction code with noise.
+    
+    Args:
+        num_logical_qubits (int): Number of logical qubits to protect
+        
+    Returns:
+        QuantumCircuit: Circuit implementing noisy Shor code
+    """
+    n_qubits = 9 * num_logical_qubits  # 9 physical qubits per logical qubit
+    qc = QuantumCircuit(n_qubits, n_qubits)
+    
+    # Encode logical qubits
+    for i in range(0, n_qubits, 9):
+        # First level encoding
+        qc.cx(i, i+1)
+        qc.cx(i, i+2)
+        
+        # Second level encoding
+        qc.h(i+3)
+        qc.h(i+6)
+        qc.cx(i+3, i+4)
+        qc.cx(i+3, i+5)
+        qc.cx(i+6, i+7)
+        qc.cx(i+6, i+8)
+        
+    # Add stabilizer measurements
+    for i in range(0, n_qubits, 9):
+        # First level stabilizers
+        qc.h(i)
+        qc.cx(i, i+1)
+        qc.cx(i, i+2)
+        qc.h(i)
+        
+        # Second level stabilizers
+        for j in range(3, 9, 3):
+            qc.h(i+j)
+            qc.cx(i+j, i+j+1)
+            qc.cx(i+j, i+j+2)
+            qc.h(i+j)
+            
+    return qc
+
+def apply_charge_preserving_qec(qc, num_qubits=7, num_classical=2):
+    """
+    Apply charge-preserving error correction to an existing circuit.
+    
+    Args:
+        qc (QuantumCircuit): Circuit to protect
+        num_qubits (int): Number of qubits in the circuit
+        num_classical (int): Number of classical bits for syndrome measurement
+        
+    Returns:
+        QuantumCircuit: Circuit with error correction
+    """
+    # Add ancilla qubits for syndrome measurement
+    qc_ec = QuantumCircuit(num_qubits + num_classical, num_classical)
+    
+    # Copy original circuit
+    for instruction, qargs, cargs in qc.data:
+        qc_ec.append(instruction, qargs, cargs)
+        
+    # Add stabilizer measurements
+    for i in range(num_classical):
+        qc_ec.h(num_qubits + i)
+        qc_ec.cx(num_qubits + i, i)
+        qc_ec.cx(num_qubits + i, i+1)
+        qc_ec.h(num_qubits + i)
+        qc_ec.measure(num_qubits + i, i)
+        
+    return qc_ec
+
+def detect_and_correct_errors(qc, logical_qubit_start):
+    """
+    Detect and correct errors in a quantum circuit.
+    
+    Args:
+        qc (QuantumCircuit): Circuit to check
+        logical_qubit_start (int): Starting index of logical qubit
+        
+    Returns:
+        QuantumCircuit: Circuit with error correction
+    """
+    # Add syndrome measurement
+    qc.h(logical_qubit_start)
+    qc.cx(logical_qubit_start, logical_qubit_start + 1)
+    qc.cx(logical_qubit_start, logical_qubit_start + 2)
+    qc.h(logical_qubit_start)
+    
+    # Measure syndrome
+    qc.measure(logical_qubit_start, 0)
+    
+    # Apply correction based on syndrome
+    qc.x(logical_qubit_start).c_if(0, 1)
+    
+    return qc 

--- a/quantum/gravity/black_hole.py
+++ b/quantum/gravity/black_hole.py
@@ -1,0 +1,131 @@
+"""
+Black hole quantum simulation functions.
+This module provides tools for simulating black hole physics using quantum circuits.
+"""
+
+from qiskit import QuantumCircuit, Aer
+from qiskit.quantum_info import Statevector
+import numpy as np
+from typing import Dict, List, Tuple
+
+def black_hole_simulation(num_qubits=17, num_charge_cycles=5, spin_cycles=3, injection_strength=np.pi/4):
+    """
+    Simulate a quantum black hole with specified parameters.
+    
+    Args:
+        num_qubits (int): Number of qubits in the simulation
+        num_charge_cycles (int): Number of charge injection cycles
+        spin_cycles (int): Number of spin cycles
+        injection_strength (float): Strength of charge injection
+        
+    Returns:
+        QuantumCircuit: Circuit implementing black hole simulation
+    """
+    qc = QuantumCircuit(num_qubits)
+    
+    def prolonged_charge_injection():
+        for i in range(num_charge_cycles):
+            qc.rz(injection_strength, 0)
+            qc.cx(0, 1)
+            
+    def spin_cycle():
+        for i in range(spin_cycles):
+            qc.h(0)
+            qc.cx(0, 1)
+            
+    def measure_entropy_fidelity():
+        state = Statevector.from_instruction(qc)
+        return entropy(state, list(range(num_qubits//2)))
+    
+    prolonged_charge_injection()
+    spin_cycle()
+    return qc
+
+def information_paradox_test(num_qubits=10, injection_strength=np.pi/2, retrieval_cycles=5):
+    """
+    Test the black hole information paradox using quantum circuits.
+    
+    Args:
+        num_qubits (int): Number of qubits in the simulation
+        injection_strength (float): Strength of information injection
+        retrieval_cycles (int): Number of retrieval attempts
+        
+    Returns:
+        QuantumCircuit: Circuit implementing information paradox test
+    """
+    qc = QuantumCircuit(num_qubits)
+    
+    # Initial information encoding
+    qc.h(0)
+    for i in range(1, num_qubits):
+        qc.cx(0, i)
+        
+    # Information scrambling
+    for _ in range(retrieval_cycles):
+        qc.rz(injection_strength, 0)
+        qc.cx(0, 1)
+        qc.h(0)
+        
+    return qc
+
+def hawking_radiation_recovery(num_qubits=10, injection_strength=np.pi/2, radiation_qubits=2, retrieval_cycles=5):
+    """
+    Simulate Hawking radiation and information recovery.
+    
+    Args:
+        num_qubits (int): Total number of qubits
+        injection_strength (float): Strength of radiation
+        radiation_qubits (int): Number of radiation qubits
+        retrieval_cycles (int): Number of retrieval attempts
+        
+    Returns:
+        QuantumCircuit: Circuit implementing Hawking radiation simulation
+    """
+    qc = QuantumCircuit(num_qubits)
+    
+    # Create entangled black hole-radiation system
+    qc.h(0)
+    for i in range(1, radiation_qubits + 1):
+        qc.cx(0, i)
+        
+    # Simulate radiation emission
+    for _ in range(retrieval_cycles):
+        qc.rz(injection_strength, 0)
+        qc.cx(0, radiation_qubits)
+        
+    return qc
+
+def create_black_hole_curvature(rows, cols, mass_strength=1.0, center=None, epsilon=1e-2):
+    """
+    Create a quantum circuit simulating black hole curvature.
+    
+    Args:
+        rows (int): Number of rows in the lattice
+        cols (int): Number of columns in the lattice
+        mass_strength (float): Strength of mass deformation
+        center (tuple): Center coordinates of the black hole
+        epsilon (float): Small parameter for numerical stability
+        
+    Returns:
+        QuantumCircuit: Circuit implementing black hole curvature
+    """
+    n_qubits = rows * cols
+    qc = QuantumCircuit(n_qubits)
+    
+    if center is None:
+        center = (rows//2, cols//2)
+        
+    # Create vacuum state
+    for i in range(n_qubits):
+        qc.h(i)
+        
+    # Apply mass deformation
+    center_idx = center[0] * cols + center[1]
+    qc.rz(mass_strength, center_idx)
+    
+    # Create entanglement structure
+    for i in range(n_qubits):
+        if i != center_idx:
+            qc.cx(center_idx, i)
+            
+    return qc 

--- a/quantum/utils/quantum_utils.py
+++ b/quantum/utils/quantum_utils.py
@@ -1,0 +1,130 @@
+"""
+Quantum utility functions.
+This module provides various utility functions for quantum circuit manipulation and analysis.
+"""
+
+from qiskit import QuantumCircuit, Aer
+from qiskit.quantum_info import Statevector
+import numpy as np
+from typing import Dict, List, Tuple
+
+def get_best_backend(service, min_qubits=3, max_queue=10):
+    """
+    Get the best available quantum backend.
+    
+    Args:
+        service: Qiskit service instance
+        min_qubits (int): Minimum number of qubits required
+        max_queue (int): Maximum acceptable queue length
+        
+    Returns:
+        Backend: Best available quantum backend
+    """
+    backends = service.backends()
+    available = [b for b in backends if b.configuration().n_qubits >= min_qubits]
+    if not available:
+        return Aer.get_backend('aer_simulator')
+    return min(available, key=lambda b: b.status().pending_jobs)
+
+def is_simulator(backend):
+    """
+    Check if a backend is a simulator.
+    
+    Args:
+        backend: Qiskit backend
+        
+    Returns:
+        bool: True if backend is a simulator
+    """
+    return backend.name().startswith('aer') or backend.name().startswith('qasm')
+
+def select_backend(use_simulator=True, hardware_backend=None):
+    """
+    Select an appropriate quantum backend.
+    
+    Args:
+        use_simulator (bool): Whether to use a simulator
+        hardware_backend (str): Name of hardware backend to use
+        
+    Returns:
+        Backend: Selected quantum backend
+    """
+    if use_simulator:
+        return Aer.get_backend('aer_simulator')
+    return hardware_backend
+
+def initialize_qubits(num_qubits):
+    """
+    Initialize a quantum circuit with specified number of qubits.
+    
+    Args:
+        num_qubits (int): Number of qubits to initialize
+        
+    Returns:
+        QuantumCircuit: Initialized quantum circuit
+    """
+    qc = QuantumCircuit(num_qubits)
+    for i in range(num_qubits):
+        qc.h(i)
+    return qc
+
+def apply_entanglement(qc, qr):
+    """
+    Apply entanglement to a quantum circuit.
+    
+    Args:
+        qc (QuantumCircuit): Circuit to modify
+        qr (QuantumRegister): Quantum register to entangle
+        
+    Returns:
+        QuantumCircuit: Circuit with entanglement
+    """
+    for i in range(len(qr)-1):
+        qc.cx(qr[i], qr[i+1])
+    return qc
+
+def measure_and_reset(qc, qr, cr):
+    """
+    Measure qubits and reset them to |0⟩.
+    
+    Args:
+        qc (QuantumCircuit): Circuit to modify
+        qr (QuantumRegister): Quantum register to measure
+        cr (ClassicalRegister): Classical register for results
+        
+    Returns:
+        QuantumCircuit: Circuit with measurements and resets
+    """
+    for i in range(len(qr)):
+        qc.measure(qr[i], cr[i])
+        qc.reset(qr[i])
+    return qc
+
+def run_circuit_statevector(qc):
+    """
+    Run a circuit and return its statevector.
+    
+    Args:
+        qc (QuantumCircuit): Circuit to run
+        
+    Returns:
+        Statevector: Final statevector of the circuit
+    """
+    backend = Aer.get_backend('statevector_simulator')
+    job = backend.run(qc)
+    return job.result().get_statevector()
+
+def process_sampler_result(result, shots=8192):
+    """
+    Process results from a quantum circuit execution.
+    
+    Args:
+        result: Result from circuit execution
+        shots (int): Number of measurement shots
+        
+    Returns:
+        Dict: Processed results
+    """
+    counts = result.get_counts()
+    total = sum(counts.values())
+    return {k: v/total for k, v in counts.items()} 


### PR DESCRIPTION
I've reorganized the large file into a more maintainable package structure with the following key components:

1. quantum/circuits/basic_circuits.py: Basic quantum circuit creation and manipulation functions
2. quantum/analysis/entropy.py: Entropy and measurement analysis functions
3. quantum/gravity/black_hole.py: Black hole simulation functions
4. quantum/communication/quantum_telephone.py: Quantum communication protocols
5. quantum/error_correction/qec.py: Quantum error correction functions
6. quantum/utils/quantum_utils.py: Utility functions for quantum operations

Each module is properly documented with docstrings and type hints. The main package's __init__.py exposes the key functionality for easy importing.